### PR TITLE
fix(convert): curate PR #7 conversion fixes and keep scope tight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,19 @@ Releases are tagged in the [GitHub repository](https://github.com/accesswatch/ac
 
 ### Fixed
 
+- **Markdown to PDF styling cascade now preserves ACB formatting.**
+  `desktop/src/acb_large_print/pandoc_converter.py` now embeds PDF CSS using
+  Pandoc `--include-in-header` in the intermediate HTML, then renders that
+  HTML directly with WeasyPrint. This prevents Pandoc default styling from
+  overriding ACB heading/list/link styles in PDF output.
+
+- **DOCX conversion line wrapping and LibreOffice input support improved.**
+  Added `--wrap=none` for Pandoc DOCX generation to avoid soft-wrap line
+  breaks in generated XML. Added `.fodt` as a native Pandoc input and added
+  `.ods/.fods/.odp/.fodp` upload support with optional LibreOffice
+  pre-conversion (`soffice`) into `.xlsx/.pptx` before the existing
+  MarkItDown-to-Pandoc chain.
+
 - **PDF tables now preserved in Word / HTML / EPUB exports.** When a PDF
   containing embedded tables is uploaded and converted to Word (`.docx`),
   HTML, EPUB, or any other Pandoc-backed output format, the tables are now

--- a/desktop/src/acb_large_print/pandoc_converter.py
+++ b/desktop/src/acb_large_print/pandoc_converter.py
@@ -31,6 +31,7 @@ PANDOC_INPUT_EXTENSIONS: set[str] = {
     ".md",  # Markdown (GFM)
     ".rst",  # reStructuredText
     ".odt",  # OpenDocument Text
+    ".fodt",  # Flat OpenDocument Text
     ".rtf",  # Rich Text Format
     ".docx",  # Word (Pandoc's own reader)
     ".epub",  # ePub e-books
@@ -41,6 +42,7 @@ _INPUT_FORMAT: dict[str, str] = {
     ".md": "gfm",
     ".rst": "rst",
     ".odt": "odt",
+    ".fodt": "odt",
     ".rtf": "rtf",
     ".docx": "docx",
     ".epub": "epub",
@@ -438,6 +440,7 @@ def convert_to_docx(
     cmd = [
         exe,
         "--standalone",
+        "--wrap=none",
         "--from",
         input_fmt,
         "--to",
@@ -750,7 +753,8 @@ def convert_to_pdf(
 
     tmp_dir = Path(tempfile.mkdtemp())
     try:
-        # Step 1: Pandoc -> HTML (intermediate, no CSS -- we apply CSS in WeasyPrint)
+        # Step 1: Pandoc -> standalone HTML with ACB CSS embedded in <head>.
+        # This ensures our stylesheet wins by cascade order in the rendered HTML.
         html_intermediate = tmp_dir / f"{src_path.stem}.html"
         input_fmt = _INPUT_FORMAT.get(ext, "markdown")
 
@@ -761,6 +765,17 @@ def convert_to_pdf(
             input_fmt,
             "--to",
             "html5",
+        ]
+
+        if pdf_css:
+            header_file = tmp_dir / "acb-pdf-header.html"
+            header_file.write_text(
+                f"<style>\n{pdf_css}\n</style>\n",
+                encoding="utf-8",
+            )
+            cmd += ["--include-in-header", str(header_file)]
+
+        cmd += [
             "--metadata",
             f"title={title}",
             "--metadata",
@@ -785,15 +800,12 @@ def convert_to_pdf(
                 f"{stderr}"
             )
 
-        # Step 2: WeasyPrint renders HTML + ACB CSS -> PDF
+        # Step 2: WeasyPrint renders HTML -> PDF. CSS is already embedded.
         log.info(
             "WeasyPrint: rendering %s -> %s", html_intermediate.name, output_path.name
         )
         html_doc = weasyprint.HTML(filename=str(html_intermediate))
-        stylesheets = []
-        if pdf_css:
-            stylesheets.append(weasyprint.CSS(string=pdf_css))
-        html_doc.write_pdf(str(output_path), stylesheets=stylesheets)
+        html_doc.write_pdf(str(output_path))
 
         size = output_path.stat().st_size
         log.info(
@@ -806,3 +818,95 @@ def convert_to_pdf(
 
     finally:
         shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+# LibreOffice-native formats that should be pre-converted before MarkItDown.
+LIBREOFFICE_CONVERSIONS: dict[str, str] = {
+    ".ods": ".xlsx",
+    ".fods": ".xlsx",
+    ".odp": ".pptx",
+    ".fodp": ".pptx",
+}
+
+
+def libreoffice_available() -> bool:
+    """Return True if the LibreOffice CLI is installed and reachable."""
+    return shutil.which("soffice") is not None
+
+
+def preconvert_via_libreoffice(
+    src_path: Path,
+    target_ext: str,
+    out_dir: Path,
+) -> Path | None:
+    """Pre-convert a LibreOffice format to Office XML via ``soffice``.
+
+    Returns the converted path on success, else ``None`` so callers can
+    continue with their normal conversion path.
+    """
+    exe = shutil.which("soffice")
+    if not exe:
+        return None
+
+    src_path = Path(src_path)
+    out_dir = Path(out_dir)
+    target_ext = target_ext.lower()
+
+    if not src_path.exists() or not out_dir.exists() or not target_ext.startswith("."):
+        return None
+
+    try:
+        # Re-discover source by directory listing to keep path provenance local.
+        src_path = next(
+            (
+                f
+                for f in src_path.parent.iterdir()
+                if f.is_file() and f.name == src_path.name
+            ),
+            src_path,
+        )
+    except OSError:
+        return None
+
+    fmt = target_ext.lstrip(".")
+    cmd = [
+        exe,
+        "--headless",
+        "--convert-to",
+        fmt,
+        "--outdir",
+        str(out_dir),
+        str(src_path),
+    ]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+
+    if result.returncode != 0:
+        log.warning(
+            "LibreOffice pre-conversion failed (%s -> %s): %s",
+            src_path.name,
+            target_ext,
+            (result.stderr or "").strip(),
+        )
+        return None
+
+    out_name = f"{src_path.stem}{target_ext}"
+    converted = next(
+        (
+            f
+            for f in out_dir.iterdir()
+            if f.is_file() and f.name.lower() == out_name.lower()
+        ),
+        None,
+    )
+    if converted and converted.exists():
+        return converted
+    return None

--- a/web/src/acb_large_print_web/routes/convert.py
+++ b/web/src/acb_large_print_web/routes/convert.py
@@ -30,6 +30,7 @@ from acb_large_print.converter import (
 from acb_large_print.exporter import export_cms_fragment
 from acb_large_print.pandoc_converter import (
     PANDOC_INPUT_EXTENSIONS,
+    LIBREOFFICE_CONVERSIONS,
     convert_to_html,
     convert_to_docx,
     convert_to_odt,
@@ -37,6 +38,8 @@ from acb_large_print.pandoc_converter import (
     convert_to_pdf,
     pandoc_available,
     weasyprint_available,
+    libreoffice_available,
+    preconvert_via_libreoffice,
 )
 from acb_large_print.pipeline_converter import (
     PIPELINE_INPUT_EXTENSIONS,
@@ -131,6 +134,10 @@ _CHAIN_VIA_MARKDOWN: frozenset[str] = frozenset({
     ".htm",   # HTML (alternate extension)
     ".json",  # JSON data
     ".xml",   # XML data
+    ".ods",   # LibreOffice Calc
+    ".fods",  # Flat ODF Spreadsheet
+    ".odp",   # LibreOffice Impress
+    ".fodp",  # Flat ODF Presentation
 })
 
 # All formats accepted by Pandoc outputs after chaining is accounted for
@@ -201,6 +208,7 @@ def _template_context(**extra):
         all_accept=_ALL_ACCEPT,
         pandoc_installed=pandoc_available(),
         weasyprint_installed=weasyprint_available(),
+        libreoffice_installed=libreoffice_available(),
         pipeline_installed=pipeline_available(),
         pipeline_conversions=pipeline_conversions,
         convert_enabled=convert_enabled,
@@ -219,6 +227,7 @@ def _template_context(**extra):
         pandoc_effective_exts=sorted(_PANDOC_EFFECTIVE_EXTENSIONS),
         markitdown_exts=sorted(CONVERTIBLE_EXTENSIONS),
         pipeline_exts=sorted(PIPELINE_INPUT_EXTENSIONS),
+        libreoffice_exts=sorted(LIBREOFFICE_CONVERSIONS),
         **extra,
     )
 
@@ -302,6 +311,24 @@ def convert_submit():
         _record_usage("convert", detail=direction)
 
         temp_dir = get_temp_dir(token)
+
+        # Pre-convert LibreOffice-native formats before entering the normal
+        # MarkItDown->Pandoc chain. If LibreOffice is missing or conversion
+        # fails, continue with the original file path.
+        if temp_dir is not None and ext in LIBREOFFICE_CONVERSIONS:
+            lo_path = preconvert_via_libreoffice(
+                saved_path,
+                LIBREOFFICE_CONVERSIONS[ext],
+                temp_dir,
+            )
+            if lo_path is not None:
+                current_app.logger.info(
+                    "CONVERT libreoffice_preconvert ext=%s -> %s",
+                    ext,
+                    lo_path.suffix.lower(),
+                )
+                saved_path = lo_path
+                ext = saved_path.suffix.lower()
 
         if direction == "to-speech":
             # Seamless handoff: keep upload session and move directly to Speech Studio.

--- a/web/src/acb_large_print_web/upload.py
+++ b/web/src/acb_large_print_web/upload.py
@@ -35,7 +35,12 @@ AUDIO_EXTENSIONS = {
 CONVERT_EXTENSIONS = ALLOWED_EXTENSIONS | {
     ".rst",
     ".odt",
+    ".fodt",  # Flat OpenDocument Text
     ".rtf",  # Pandoc inputs
+    ".ods",  # LibreOffice Calc
+    ".fods",  # Flat ODF Spreadsheet
+    ".odp",  # LibreOffice Impress
+    ".fodp",  # Flat ODF Presentation
     ".html",
     ".htm",  # MarkItDown
     ".csv",

--- a/web/tests/test_upload.py
+++ b/web/tests/test_upload.py
@@ -173,6 +173,11 @@ class TestUploadConstants:
         assert ALLOWED_EXTENSIONS.issubset(CONVERT_EXTENSIONS)
         assert ".rst" in CONVERT_EXTENSIONS
         assert ".html" in CONVERT_EXTENSIONS
+        assert ".fodt" in CONVERT_EXTENSIONS
+        assert ".ods" in CONVERT_EXTENSIONS
+        assert ".fods" in CONVERT_EXTENSIONS
+        assert ".odp" in CONVERT_EXTENSIONS
+        assert ".fodp" in CONVERT_EXTENSIONS
 
     def test_audio_extensions_include_cloud_supported_formats(self):
         assert ".mp3" in AUDIO_EXTENSIONS


### PR DESCRIPTION
## Summary
This PR cleanly curates only the conversion-related improvements from the broader PR #7 stream, while intentionally excluding unrelated speech/Caddy/audit-rule scope.

## Included (curated)
- Fix PDF style-cascade reliability by embedding ACB CSS via Pandoc `--include-in-header` for PDF intermediate HTML, then rendering with WeasyPrint.
- Add Pandoc input support for `.fodt`.
- Add `--wrap=none` to DOCX generation to reduce soft-wrap XML line break issues.
- Add optional LibreOffice pre-conversion support for `.ods/.fods/.odp/.fodp` -> `.xlsx/.pptx` in convert flow.
- Extend convert upload extension allow-list and related tests.
- Update `CHANGELOG.md` with non-duplicate conversion-focused entries.

## Explicitly excluded from this PR
- Speech streaming/SSE changes
- Caddy configuration changes
- Audit rule and unrelated cross-surface feature changes
- Artifact files (`post_findings.json`, cleanup locks)

## Validation
- Focused tests passed:
  - `python -m pytest -q tests/test_upload.py tests/test_convert_odt.py`
- Static diagnostics for modified files: no errors.

## Traceability
- Related original broad PR: #7
- Safety parking refs for deferred work are retained in repo-local workflow branches/tags.