### PR TITLE
ci: let a pull request produce the "Run tests" check it must pass

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,11 @@ concurrency:
 
 jobs:
   test:
-    name: Run tests
+    # Named "Pre-deploy tests", not "Run tests": the required status check of
+    # that name is produced by tests.yml, which also runs on pull_request. Two
+    # workflows exporting an identically named check makes the required context
+    # ambiguous, so this one keeps its own name. It still gates the deploy below.
+    name: Pre-deploy tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,80 @@
+name: Tests
+
+# The "Run tests" required status check.
+#
+# This job used to live only in deploy.yml, which triggers on push to main and
+# workflow_dispatch -- never on pull_request. Branch protection required a
+# check named "Run tests" that a pull request could therefore never produce, so
+# every PR waited forever on a check that could not run, and the only way to
+# land anything was to push straight to main with admin enforcement disabled.
+#
+# Deliberately no `paths:` filter. A required check that is path-filtered is the
+# same trap in a smaller form: a PR touching only unfiltered paths never reports
+# the check and blocks just as permanently.
+on:
+  pull_request:
+  push:
+    branches: [main, "release/**"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+
+          install_with_retry() {
+            local max_attempts="$1"
+            shift
+            local attempt=1
+            local delay=5
+            while true; do
+              if "$@"; then
+                return 0
+              fi
+              if [ "$attempt" -ge "$max_attempts" ]; then
+                echo "Command failed after ${attempt} attempts: $*"
+                return 1
+              fi
+              echo "Attempt ${attempt} failed. Retrying in ${delay}s: $*"
+              sleep "$delay"
+              attempt=$((attempt + 1))
+              delay=$((delay * 2))
+            done
+          }
+
+          install_with_retry 4 python -m pip install --upgrade --force-reinstall "git+https://github.com/Community-Access/quill-glow-core.git@main"
+          install_with_retry 4 python -m pip install -e ./desktop
+          install_with_retry 4 python -m pip install -e ./web
+          install_with_retry 4 python -m pip install -r ./mcp_server/requirements.txt
+          install_with_retry 4 python -m pip install -r ./mcp_server/tests/requirements.txt
+          install_with_retry 4 python -m pip install pytest
+
+      - name: Install Pandoc
+        run: sudo apt-get install -y pandoc
+
+      - name: Verify MCP test dependencies
+        run: |
+          python -c "import fastapi, starlette, pydantic"
+
+      - name: Run web tests
+        run: python -m pytest web/tests/ -x -q
+
+      - name: Run MCP server tests
+        run: python -m pytest mcp_server/tests/ -x -q

--- a/BRANCH_PROTECTION_RULES.md
+++ b/BRANCH_PROTECTION_RULES.md
@@ -6,8 +6,19 @@ The Community-Access/glow repository enforces branch protection rules on the `ma
 
 ### Status Checks
 - **Required:** All CI workflows must pass before merge (strict mode)
-- **Tests:** "Run tests" workflow must complete successfully
+- **Tests:** "Run tests" must complete successfully. This check is produced by
+  `.github/workflows/tests.yml`, which runs on `pull_request` **and** on pushes
+  to `main`.
 - **Branch must be up-to-date:** New commits to base branch require re-sync before merge
+
+> **Why "Run tests" has its own workflow.** It previously lived only in
+> `deploy.yml`, which triggers on push and `workflow_dispatch` but never on
+> `pull_request`. A pull request could therefore never produce the check it was
+> required to pass, so every PR blocked indefinitely and admin enforcement was
+> switched off so work could land by pushing directly to `main`. If this check
+> is ever moved or renamed, update the required-status-check context at the same
+> time, and keep it free of a `paths:` filter — a path-filtered required check
+> silently reintroduces the same deadlock for PRs that touch other paths.
 
 ### Code Review
 - **Minimum reviews:** 1 approving review required before merge

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,6 +4,22 @@
 
 ## Quick Reference
 
+> **Production deploys are automatic.** Pushing to `main` (or `release/**`) with
+> changes under `web/`, `mcp_server/`, `desktop/src/`, the deploy scripts, or
+> `CHANGELOG.md` triggers the **Deploy Web App** workflow, which runs
+> `deploy-app.sh` on the server over SSH. In the normal case you do not need to
+> log in and deploy anything by hand.
+>
+> **Do not run `deploy-app.sh` manually while an Actions deploy may be running.**
+> The workflow's `concurrency: deploy-production` group serialises Actions runs
+> against each other, but it cannot see a person on SSH. Two concurrent runs
+> collide in `docker compose up` and the deploy fails with
+> `Conflict. The container name "..._web-web-1" is already in use` — this has
+> happened. Before any manual deploy, check the Actions tab (or
+> `gh run list --workflow=deploy.yml`) and wait for in-flight runs to finish.
+> Manual deploys are for recovery, a `workflow_dispatch` re-run, or when Actions
+> itself is unavailable.
+
 - **Automated Deployment Script:** `bash ~/app/scripts/deploy-app.sh`
 - **Manual Maintenance Toggle:** `bash ~/app/scripts/maintenance-mode.sh {on|off|status}`
 - **Complete Strategy & Troubleshooting:** The full deployment strategy is maintained in the repository documentation for operators working from the source tree.

--- a/web/e2e/tests/regression.spec.mjs
+++ b/web/e2e/tests/regression.spec.mjs
@@ -148,7 +148,13 @@ test.describe('GLOW web regression suite', () => {
     throw new Error('Template flow produced neither direct download nor job progress redirect');
   });
 
-  test('site-audit flow scans local page and renders artifact links', async ({ page, baseURL }) => {
+  // Named for what it actually verifies. The SSRF guard refuses private
+  // addresses, so a scan aimed at this test server is always refused: this
+  // exercises submission, the results page, and the artifact links, and asserts
+  // the refusal is reported honestly. It does NOT prove scanning works -- the
+  // scan engine is covered by web/tests/test_site_audit.py, and the results
+  // page in its populated state by the seeded audit in axe-audit.spec.mjs.
+  test('site-audit flow renders results and reports a refused scan', async ({ page, baseURL }) => {
     test.setTimeout(120000);
 
     await page.goto('/site-audit/');
@@ -177,6 +183,16 @@ test.describe('GLOW web regression suite', () => {
     await expect(page.getByRole('link', { name: /Download JSON summary/i })).toBeVisible();
     await expect(page.getByRole('link', { name: /Download findings CSV/i })).toBeVisible();
     await expect(page.getByRole('link', { name: /Download complete bundle \(ZIP\)/i })).toBeVisible();
+
+    // The refused page must be reported as a failure, not silently counted as
+    // scanned. Without this the test passes identically whether the run
+    // reported an honest error or wrongly claimed a clean page.
+    const perPageRow = page.locator('table', { has: page.locator('caption', { hasText: /Pages included in this scan run/i }) })
+      .locator('tbody tr')
+      .first();
+    await expect(perPageRow).toContainText('error');
+    await expect(page.getByRole('listitem').filter({ hasText: /^Failed:/ })).toContainText('1');
+    await expect(page.getByRole('listitem').filter({ hasText: /^Scanned:/ })).toContainText('0');
   });
 
   test('static reference pages load', async ({ page }) => {


### PR DESCRIPTION
## Why

Branch protection requires a status check named **`Run tests`**. That job existed only in `deploy.yml`, which triggers on `push` to `main` and `workflow_dispatch` — **never on `pull_request`**.

So a PR could never produce the check it was required to pass. Every PR blocked indefinitely, `enforce_admins` was switched off, and pushing directly to `main` became the only way to land anything.

## What this changes

- **`.github/workflows/tests.yml` (new)** — produces `Run tests` on `pull_request` and on pushes to `main`. Deliberately **no `paths:` filter**: a path-filtered required check recreates the same deadlock for any PR touching other paths.
- **`deploy.yml`** — its gating job is renamed `Pre-deploy tests` so only one workflow exports the required context. The deploy is still gated.
- **`docs/deployment.md`** — records that production deploys are automatic on push to `main`, and that running `deploy-app.sh` by hand can collide with the Actions deploy. The `concurrency: deploy-production` group serialises Actions runs against each other but cannot see a person on SSH; two concurrent runs fail in `docker compose up` with a container-name conflict. This happened during this work.
- **`BRANCH_PROTECTION_RULES.md`** — documents where the check lives and the path-filter trap.
- **`web/e2e/tests/regression.spec.mjs`** — renames the site-audit test to say what it verifies. The SSRF guard refuses private addresses, so a scan aimed at the test server is always refused: the test exercised submission, the results page and artifact links, but never scanning, while its name claimed otherwise. It now also asserts the refusal is reported honestly (`failed=1`, `scanned=0`, per-page result `error`).

## Verification

This PR is its own test: if `Run tests` reports here, the deadlock is fixed.

Once it does, `enforce_admins` should be turned on so the setting matches the documented policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)